### PR TITLE
Fix Blender 5.0 compatibility: context override and region access

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "python-envs.pythonProjects": []
+}

--- a/node_minimap/draw_handlers.py
+++ b/node_minimap/draw_handlers.py
@@ -50,7 +50,10 @@ def handler_create(self: MINIMAP_OT_InitDrawOperators, context: bpy.types.Contex
 
 def draw_callback_px(self: MINIMAP_OT_DrawAreaMinimap, context: bpy.types.Context):
     """Called by every operator when there's a redraw"""
-    area = get_area(self, context)
+    try:
+        area = get_area(self, context)
+    except ReferenceError:
+        return
     # the operator context.area remains the same even when the actual context is updated
     if context.area != area:
         # This filters out calls from operators that arent in the correct area,

--- a/node_minimap/minimap_functions.py
+++ b/node_minimap/minimap_functions.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from mathutils import Vector as V
 from ..shared.helpers import Rectangle, vec_lerp, vec_multiply
-from ..shared.functions import get_prefs, pos_to_fac, get_node_dims, draw_lines_from_quad_2d
+from ..shared.functions import get_prefs, pos_to_fac, get_node_dims, draw_lines_from_quad_2d, get_region
 
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
@@ -10,9 +10,9 @@ if TYPE_CHECKING:
 
 def get_map_area(context, area, node_area) -> Rectangle:
     """Returns a rectangle representing the size, shape and position of the minimap box"""
-    region = area.regions[3]
+    region = get_region(area, 'WINDOW')
     # We need to take into account the size of the header
-    region_height = region.height - (area.regions[0].height / 2)
+    # region_height = region.height - (area.regions[0].height / 2)
     region_height = region.height
 
     prefs = get_prefs(context)

--- a/node_minimap/operators.py
+++ b/node_minimap/operators.py
@@ -1,6 +1,6 @@
 import bpy
 from mathutils import Vector as V
-from ..shared.functions import get_area, get_prefs
+from ..shared.functions import get_area, get_prefs, get_region
 from .minimap_functions import get_shader_cache
 from .draw_handlers import draw_callback_px, handler_create
 from .shader_cache import ShaderCache
@@ -112,7 +112,8 @@ class MINIMAP_OT_DrawAreaMinimap(bpy.types.Operator):
             if on_minimap and event.value != "RELEASE":
                 # Check for a double click by seeing if there is another mouse click in the most recent events
                 if event.type in self.prev_event_types:
-                    with context.temp_override(area=area, space=area.spaces[0], region=area.regions[3]):
+                    region = get_region(area, 'WINDOW')
+                    with context.temp_override(area=area, space=area.spaces[0], region=region):
                         bpy.ops.node.view_all()
                 context.window.cursor_modal_set("SCROLL_XY")
                 self.is_panning = True
@@ -136,7 +137,8 @@ class MINIMAP_OT_DrawAreaMinimap(bpy.types.Operator):
                             for n in node.id_data.nodes:
                                 n.select = False
                             node.select = True
-                            with context.temp_override(area=area, space=area.spaces[0], region=area.regions[3]):
+                            region = get_region(area, 'WINDOW')
+                            with context.temp_override(area=area, space=area.spaces[0], region=region):
                                 bpy.ops.node.view_selected("EXEC_DEFAULT")
                             break
 
@@ -153,7 +155,8 @@ class MINIMAP_OT_DrawAreaMinimap(bpy.types.Operator):
             delta = self.mouse_pos - self.prev_mouse_pos
             multiplier = 1 + (1 - prefs.size)
             delta *= multiplier * (self.map_area.size.x / self.view_area.size.x)
-            with context.temp_override(area=area, space=area.spaces[0], region=area.regions[3]):
+            region = get_region(area, 'WINDOW')
+            with context.temp_override(area=area, space=area.spaces[0], region=region):
                 bpy.ops.view2d.pan(deltax=int(delta.x), deltay=int(delta.y))
             return {'RUNNING_MODAL'}
         else:

--- a/node_minimap/shader_cache.py
+++ b/node_minimap/shader_cache.py
@@ -4,7 +4,7 @@ from typing import Dict, List
 from mathutils import Vector as V
 from ..shared.helpers import get_active_tree, get_alt_node_tree_name, vec_divide
 from ..shared.functions import draw_lines_from_quads_2d_batch, draw_quads_2d_batch, get_batch_from_quads_2d,\
-    get_batch_lines_from_quads_2d, get_node_area, get_node_color, get_node_loc, get_prefs
+    get_batch_lines_from_quads_2d, get_node_area, get_node_color, get_node_loc, get_prefs, get_region
 from .minimap_functions import get_map_area, get_node_rect
 """
 The caching system makes understanding how the minimap drawing works quite a lot harder, so if you want to do that,
@@ -72,7 +72,9 @@ class AreaCache():
         self.all_nodes: List[NodeCache]
         self.area_name = str(area)
         # get size (regions[0]) minus the n-panel (regions[1])
-        self.region_size = V((area.regions[0].width - area.regions[1].width, area.regions[0].height))
+        # self.region_size = V((area.regions[0].width - area.regions[1].width, area.regions[0].height))
+        region = get_region(area, 'WINDOW')
+        self.region_size = V((region.width, region.height))
         self.update_areas(context, force=True)
         self.current_node_tree_name = self.node_tree.name
         self.tag_update = False
@@ -84,7 +86,9 @@ class AreaCache():
         (the rectangles representing local node space and minimap space respectively), along with region size and scale
         (The scale factor between the node and map areas)"""
         # get size (regions[0]) minus the n-panel (regions[1])
-        current_size = V((self.area.regions[0].width - self.area.regions[1].width, self.area.regions[0].height))
+        # current_size = V((self.area.regions[0].width - self.area.regions[1].width, self.area.regions[0].height))
+        region = get_region(self.area, 'WINDOW')
+        current_size = V((region.width, region.height))
         if force or self.region_size != current_size:
             self.node_area = get_node_area(self.node_tree)
             self.map_area = get_map_area(context, self.area, self.node_area)

--- a/shared/functions.py
+++ b/shared/functions.py
@@ -334,3 +334,9 @@ def get_area(self, context) -> Area:
 def get_prefs(context) -> NodeExtrasPrefs:
     """Return the addon preferences"""
     return context.preferences.addons[__package__.split(".")[0]].preferences
+def get_region(area, region_type):
+    """Get the region of the given type from the area"""
+    for region in area.regions:
+        if region.type == region_type:
+            return region
+    return None


### PR DESCRIPTION
Hi, i fixed the RuntimeError and ReferenceError for Blender 5.0 by:
- Using context.temp_override with the correct 'WINDOW' region.
- Replacing hardcoded region indices (e.g., regions[3]) with a dynamic lookup.